### PR TITLE
Unset scroll view delegate in -dealloc

### DIFF
--- a/Source/Classes/DZNWebViewController.m
+++ b/Source/Classes/DZNWebViewController.m
@@ -852,6 +852,7 @@ static char DZNWebViewControllerKVOContext = 0;
     _backwardLongPress = nil;
     _forwardLongPress = nil;
     
+    _webView.scrollView.delegate = nil;
     _webView.navDelegate = nil;
     _webView.UIDelegate = nil;
     _webView = nil;


### PR DESCRIPTION
I was seeing a crash coming from `-[UIScrollView setDelegate:]` when dismissing a presented web view controller. This fixed that crash.