### PR TITLE
Only use title text attributes that are set

### DIFF
--- a/Source/Classes/DZNWebViewController.m
+++ b/Source/Classes/DZNWebViewController.m
@@ -380,15 +380,9 @@ static char DZNWebViewControllerKVOContext = 0;
         return;
     }
     
-    UIFont *titleFont = [UIFont boldSystemFontOfSize:12.0];
-    UIFont *urlFont = [UIFont systemFontOfSize:10.0];
-    UIColor *textColor = [UIColor blackColor];
-    
-    if (self.navigationBar.titleTextAttributes) {
-        titleFont = self.navigationBar.titleTextAttributes[NSFontAttributeName];
-        urlFont = [UIFont fontWithName:titleFont.fontName size:titleFont.pointSize-2.0];
-        textColor = self.navigationBar.titleTextAttributes[NSForegroundColorAttributeName];
-    }
+    UIFont *titleFont = self.navigationBar.titleTextAttributes[NSFontAttributeName] ?: [UIFont boldSystemFontOfSize:12.0];
+    UIFont *urlFont = [UIFont fontWithName:titleFont.fontName size:titleFont.pointSize-2.0];
+    UIColor *textColor = self.navigationBar.titleTextAttributes[NSForegroundColorAttributeName] ?: [UIColor blackColor];
     
     NSMutableString *text = [NSMutableString stringWithString:title];
     


### PR DESCRIPTION
It's possible that the navigation bar's attributes are set with some but not all of the attributes we want to use for our replacement title label. Previously we would crash. With this change, we'll fall back to our default values.

I don't see any existing code that uses the ternary operator this way, so let me know if you'd prefer something else!