### PR TITLE
KVO web view title

### DIFF
--- a/Source/Classes/DZNWebViewController.m
+++ b/Source/Classes/DZNWebViewController.m
@@ -144,6 +144,7 @@ static char DZNWebViewControllerKVOContext = 0;
         webView.UIDelegate = self;
         webView.navDelegate = self;
         webView.scrollView.delegate = self;
+        [webView addObserver:self forKeyPath:@"title" options:NSKeyValueObservingOptionNew context:&DZNWebViewControllerKVOContext];
         
         _webView = webView;
     }
@@ -670,16 +671,12 @@ static char DZNWebViewControllerKVOContext = 0;
 - (void)webView:(DZNWebView *)webView didFinishNavigation:(WKNavigation *)navigation
 {
     [self updateToolbarItems];
-    
-    self.title = self.webView.title;
 }
 
 - (void)webView:(DZNWebView *)webView didFailNavigation:(WKNavigation *)navigation withError:(NSError *)error
 {
     [self updateToolbarItems];
     [self setLoadingError:error];
-    
-    self.title = nil;
 }
 
 
@@ -809,6 +806,12 @@ static char DZNWebViewControllerKVOContext = 0;
             }
         }
     }
+    else if ([object isEqual:self.webView]) {
+        
+        if ([keyPath isEqualToString:@"title"]) {
+            self.title = change[NSKeyValueChangeNewKey];
+        }
+    }
 }
 
 
@@ -852,6 +855,7 @@ static char DZNWebViewControllerKVOContext = 0;
     _backwardLongPress = nil;
     _forwardLongPress = nil;
     
+    [_webView removeObserver:self forKeyPath:@"title" context:&DZNWebViewControllerKVOContext];
     _webView.navDelegate = nil;
     _webView.UIDelegate = nil;
     _webView = nil;


### PR DESCRIPTION
WKWebView's `title` property is documented KVO-compliant. This is actually useful because the title is often available before `didFinishNavigation` gets called, and now we'll see the title as soon as possible.

I hope the officially-documented-as-KVO-compliant observer doesn't stick out too much ;-)