### PR TITLE
Improve loading local HTML

### DIFF
--- a/Source/Classes/DZNPolyActivity.m
+++ b/Source/Classes/DZNPolyActivity.m
@@ -59,11 +59,11 @@
 - (UIImage *)activityImage
 {
     switch (self.type) {
-        case DZNPolyActivityTypeLink:           return [UIImage imageNamed:@"dzn_icn_activity_link"];
-        case DZNPolyActivityTypeSafari:         return [UIImage imageNamed:@"dzn_icn_activity_safari"];
-        case DZNPolyActivityTypeChrome:         return [UIImage imageNamed:@"dzn_icn_activity_chrome"];
-        case DZNPolyActivityTypeOpera:          return [UIImage imageNamed:@"dzn_icn_activity_opera"];
-        case DZNPolyActivityTypeDolphin:        return [UIImage imageNamed:@"dzn_icn_activity_dolphin"];
+        case DZNPolyActivityTypeLink:           return [UIImage imageNamed:@"dzn_icn_activity_link" inBundle:[NSBundle bundleForClass:DZNPolyActivity.self] compatibleWithTraitCollection:nil];
+        case DZNPolyActivityTypeSafari:         return [UIImage imageNamed:@"dzn_icn_activity_safari" inBundle:[NSBundle bundleForClass:DZNPolyActivity.self] compatibleWithTraitCollection:nil];
+        case DZNPolyActivityTypeChrome:         return [UIImage imageNamed:@"dzn_icn_activity_chrome" inBundle:[NSBundle bundleForClass:DZNPolyActivity.self] compatibleWithTraitCollection:nil];
+        case DZNPolyActivityTypeOpera:          return [UIImage imageNamed:@"dzn_icn_activity_opera" inBundle:[NSBundle bundleForClass:DZNPolyActivity.self] compatibleWithTraitCollection:nil];
+        case DZNPolyActivityTypeDolphin:        return [UIImage imageNamed:@"dzn_icn_activity_dolphin" inBundle:[NSBundle bundleForClass:DZNPolyActivity.self] compatibleWithTraitCollection:nil];
         default:                                return nil;
     }
 }

--- a/Source/Classes/DZNWebViewController.h
+++ b/Source/Classes/DZNWebViewController.h
@@ -86,6 +86,13 @@ typedef NS_OPTIONS(NSUInteger, DZNsupportedWebActions) {
  */
 - (void)loadURL:(NSURL *)URL NS_REQUIRES_SUPER;
 
+/**
+ Starts loading a new request. Useful to programatically update the web content.
+
+ @param URL The HTTP or file URL to be requested.
+ @param baseURL A URL that is used to resolve relative URLs within the document.
+ */
+- (void)loadURL:(NSURL *)URL baseURL:(NSURL *)baseURL;
 
 ///------------------------------------------------
 /// @name Appearance customisation

--- a/Source/Classes/DZNWebViewController.m
+++ b/Source/Classes/DZNWebViewController.m
@@ -425,11 +425,17 @@ static char DZNWebViewControllerKVOContext = 0;
 
 - (void)loadURL:(NSURL *)URL
 {
+    NSURL *baseURL = [[NSURL alloc] initFileURLWithPath:URL.path.stringByDeletingLastPathComponent isDirectory:YES];
+    [self loadURL:URL baseURL:baseURL];
+}
+
+- (void)loadURL:(NSURL *)URL baseURL:(NSURL *)baseURL
+{
     if ([URL isFileURL]) {
         NSData *data = [[NSData alloc] initWithContentsOfURL:URL];
         NSString *HTMLString = [[NSString alloc] initWithData:data encoding:NSStringEncodingConversionAllowLossy];
-        
-        [self.webView loadHTMLString:HTMLString baseURL:nil];
+
+        [self.webView loadHTMLString:HTMLString baseURL:baseURL];
     }
     else {
         NSURLRequest *request = [[NSURLRequest alloc] initWithURL:URL];

--- a/Source/Classes/DZNWebViewController.m
+++ b/Source/Classes/DZNWebViewController.m
@@ -248,7 +248,7 @@ static char DZNWebViewControllerKVOContext = 0;
 - (UIImage *)backwardButtonImage
 {
     if (!_backwardButtonImage) {
-        _backwardButtonImage = [UIImage imageNamed:@"dzn_icn_toolbar_backward"];
+        _backwardButtonImage = [UIImage imageNamed:@"dzn_icn_toolbar_backward" inBundle:[NSBundle bundleForClass:DZNWebViewController.self] compatibleWithTraitCollection:nil];
     }
     return _backwardButtonImage;
 }
@@ -256,7 +256,7 @@ static char DZNWebViewControllerKVOContext = 0;
 - (UIImage *)forwardButtonImage
 {
     if (!_forwardButtonImage) {
-        _forwardButtonImage = [UIImage imageNamed:@"dzn_icn_toolbar_forward"];
+        _forwardButtonImage = [UIImage imageNamed:@"dzn_icn_toolbar_forward" inBundle:[NSBundle bundleForClass:DZNWebViewController.self] compatibleWithTraitCollection:nil];
     }
     return _forwardButtonImage;
 }
@@ -264,7 +264,7 @@ static char DZNWebViewControllerKVOContext = 0;
 - (UIImage *)reloadButtonImage
 {
     if (!_reloadButtonImage) {
-        _reloadButtonImage = [UIImage imageNamed:@"dzn_icn_toolbar_reload"];
+        _reloadButtonImage = [UIImage imageNamed:@"dzn_icn_toolbar_reload" inBundle:[NSBundle bundleForClass:DZNWebViewController.self] compatibleWithTraitCollection:nil];
     }
     return _reloadButtonImage;
 }
@@ -272,7 +272,7 @@ static char DZNWebViewControllerKVOContext = 0;
 - (UIImage *)stopButtonImage
 {
     if (!_stopButtonImage) {
-        _stopButtonImage = [UIImage imageNamed:@"dzn_icn_toolbar_stop"];
+        _stopButtonImage = [UIImage imageNamed:@"dzn_icn_toolbar_stop" inBundle:[NSBundle bundleForClass:DZNWebViewController.self] compatibleWithTraitCollection:nil];
     }
     return _stopButtonImage;
 }
@@ -280,7 +280,7 @@ static char DZNWebViewControllerKVOContext = 0;
 - (UIImage *)actionButtonImage
 {
     if (!_actionButtonImage) {
-        _actionButtonImage = [UIImage imageNamed:@"dzn_icn_toolbar_action"];
+        _actionButtonImage = [UIImage imageNamed:@"dzn_icn_toolbar_action" inBundle:[NSBundle bundleForClass:DZNWebViewController.self] compatibleWithTraitCollection:nil];
     }
     return _actionButtonImage;
 }


### PR DESCRIPTION
Add support for specifying a base URL when loading local HTML.  This
enables loading other local sources that have relative references in
the document.  By default, sets base URL to the same directory as the
URL path.