### PR TITLE
Fixed crash when hideBarsWithGestures is set to NO

### DIFF
--- a/Source/Classes/DZNWebViewController.m
+++ b/Source/Classes/DZNWebViewController.m
@@ -840,9 +840,11 @@ static char DZNWebViewControllerKVOContext = 0;
 
 - (void)dealloc
 {
-    [self.navigationBar removeObserver:self forKeyPath:@"hidden" context:&DZNWebViewControllerKVOContext];
-    [self.navigationBar removeObserver:self forKeyPath:@"center" context:&DZNWebViewControllerKVOContext];
-    [self.navigationBar removeObserver:self forKeyPath:@"alpha" context:&DZNWebViewControllerKVOContext];
+    if (self.hideBarsWithGestures) {
+    	[self.navigationBar removeObserver:self forKeyPath:@"hidden" context:&DZNWebViewControllerKVOContext];
+    	[self.navigationBar removeObserver:self forKeyPath:@"center" context:&DZNWebViewControllerKVOContext];
+    	[self.navigationBar removeObserver:self forKeyPath:@"alpha" context:&DZNWebViewControllerKVOContext];
+    }
     
     _backwardBarItem = nil;
     _forwardBarItem = nil;


### PR DESCRIPTION
Added a single if statement to safe-check the property when dealloc is called, preventing a crash when deallocating a DZNWebViewController with self.hideBarsWithGestures = NO.