### PR TITLE
Improve reliability and robustness

### DIFF
--- a/Source/Classes/DZNWebViewController.h
+++ b/Source/Classes/DZNWebViewController.h
@@ -58,6 +58,8 @@ typedef NS_OPTIONS(NSUInteger, DZNsupportedWebActions) {
 @property (nonatomic) BOOL allowHistory;
 /** YES if both, the navigation and tool bars should hide when panning vertically. Default is YES. */
 @property (nonatomic) BOOL hideBarsWithGestures;
+/** YES if should set the title automatically based on the page title and URL. Default is YES. */
+@property (nonatomic) BOOL showPageTitleAndURL;
 
 ///------------------------------------------------
 /// @name Initialization


### PR DESCRIPTION
* Prevent the web page title from being shown instead of our own title if desired
* Prevent the toolbar from only appearing once (e.g. when this view is presented modally the `dispatch_once` was preventing the toolbar from being configured)
* Prevent delayed allocation of the webview (for simplicity with respect to KVO observer removal)
* Use KVO for controlling the toolbar icons (for accuracy and reliability when tapping reload followed immediately by stop reloading)