### PR TITLE
Made sample project work in iOS 9

### DIFF
--- a/Examples/Sample/Sample/Sample-Info.plist
+++ b/Examples/Sample/Sample/Sample-Info.plist
@@ -45,5 +45,10 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
In iOS9, a NSAppTransportSecurity property is in the plist required to allow for
non-https web requests.