### PR TITLE
show info (e.g. title/URL) on navigation bar based on a NS_OPTIONS

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ UINavigationController *NC = [[UINavigationController alloc] initWithRootViewCon
 
 WVC.supportedWebNavigationTools = DZNWebNavigationToolAll;
 WVC.supportedWebActions = DZNWebActionAll;
+WVC.infoOnNavigationBar = DZNWebInfoOnNavigationBarAll;
 WVC.showLoadingProgress = YES;
 WVC.allowHistory = YES;
 WVC.hideBarsWithGestures = YES;

--- a/Source/Classes/DZNWebViewController.h
+++ b/Source/Classes/DZNWebViewController.h
@@ -70,6 +70,8 @@ typedef NS_OPTIONS(NSUInteger, DZNWebInfoOnNavigationBar) {
 @property (nonatomic) BOOL allowHistory;
 /** YES if both, the navigation and tool bars should hide when panning vertically. Default is YES. */
 @property (nonatomic) BOOL hideBarsWithGestures;
+/** [Deprecated] YES if should set the title automatically based on the page title and URL. Default is YES. */
+@property (nonatomic) BOOL showPageTitleAndURL __deprecated_msg("Use 'infoOnNavigationBar' instead.");
 
 ///------------------------------------------------
 /// @name Initialization

--- a/Source/Classes/DZNWebViewController.h
+++ b/Source/Classes/DZNWebViewController.h
@@ -40,6 +40,16 @@ typedef NS_OPTIONS(NSUInteger, DZNsupportedWebActions) {
 };
 
 /**
+ Types of information to be shown on navigation bar
+ */
+typedef NS_OPTIONS(NSUInteger, DZNWebInfoOnNavigationBar) {
+    DZNWebInfoOnNavigationBarAll = -1,
+    DZNWebInfoOnNavigationBarNone = 0,
+    DZNWebInfoOnNavigationBarTitle = (1 << 0),
+    DZNWebInfoOnNavigationBarURL = (1 << 1),
+};
+
+/**
  A very simple web browser with useful navigation and tooling features.
  */
 @interface DZNWebViewController : UIViewController <DZNNavigationDelegate, WKUIDelegate, UITableViewDataSource, UITableViewDelegate>
@@ -52,14 +62,14 @@ typedef NS_OPTIONS(NSUInteger, DZNsupportedWebActions) {
 @property (nonatomic, readwrite) DZNWebNavigationTools supportedWebNavigationTools;
 /** The supported actions like sharing and copy link, add to reading list, open in Safari, etc. Default is All. */
 @property (nonatomic, readwrite) DZNsupportedWebActions supportedWebActions;
+/** The information to be shown on navigation bar. */
+@property (nonatomic, readwrite) DZNWebInfoOnNavigationBar infoOnNavigationBar;
 /** Yes if a progress bar indicates the . Default is YES. */
 @property (nonatomic) BOOL showLoadingProgress;
 /** YES if long pressing the backward and forward buttons the navigation history is displayed. Default is YES. */
 @property (nonatomic) BOOL allowHistory;
 /** YES if both, the navigation and tool bars should hide when panning vertically. Default is YES. */
 @property (nonatomic) BOOL hideBarsWithGestures;
-/** YES if should set the title automatically based on the page title and URL. Default is YES. */
-@property (nonatomic) BOOL showPageTitleAndURL;
 
 ///------------------------------------------------
 /// @name Initialization

--- a/Source/Classes/DZNWebViewController.m
+++ b/Source/Classes/DZNWebViewController.m
@@ -362,7 +362,7 @@ static char DZNWebViewControllerKVOContext = 0;
 
 - (void)setTitle:(NSString *)title
 {
-    if (self.infoOnNavigationBar == 0) {
+    if (self.infoOnNavigationBar == DZNWebInfoOnNavigationBarNone) {
         [super setTitle:title];
         return;
     }
@@ -689,7 +689,7 @@ static char DZNWebViewControllerKVOContext = 0;
 
 - (void)webView:(DZNWebView *)webView didFinishNavigation:(WKNavigation *)navigation
 {
-    if (self.infoOnNavigationBar > 0) {
+    if (self.infoOnNavigationBar > DZNWebInfoOnNavigationBarNone) {
         self.title = self.webView.title;
     }
 }

--- a/Source/Classes/DZNWebViewController.m
+++ b/Source/Classes/DZNWebViewController.m
@@ -436,7 +436,7 @@ static char DZNWebViewControllerKVOContext = 0;
 
 - (BOOL)showAllInfoOnNavigationBar
 {
-    return (_infoOnNavigationBar == DZNWebInfoOnNavigationBarAll) ? YES : NO;
+    return ( _infoOnNavigationBar == DZNWebInfoOnNavigationBarAll || _infoOnNavigationBar == (DZNWebInfoOnNavigationBarURL | DZNWebInfoOnNavigationBarTitle) ) ? YES : NO;
 }
 
 


### PR DESCRIPTION
Show info (e.g. title/URL) on navigation bar based on a `NS_OPTIONS(DZNWebInfoOnNavigationBar)` instead of `showPageTitleAndURL` used previously

BTW I think the name of this `NS_OPTIONS(DZNWebInfoOnNavigationBar)` can be better. Can anyone help?