### PR TITLE
Clear progressView in viewDidDisappear

### DIFF
--- a/Source/Classes/DZNWebViewController.h
+++ b/Source/Classes/DZNWebViewController.h
@@ -16,7 +16,7 @@
 /**
  Types of supported navigation tools.
  */
-typedef NS_OPTIONS(NSUInteger, DZNWebNavigationTools) {
+typedef NS_OPTIONS(NSInteger, DZNWebNavigationTools) {
     DZNWebNavigationToolAll = -1,
     DZNWebNavigationToolNone = 0,
     DZNWebNavigationToolBackward = (1 << 0),
@@ -27,7 +27,7 @@ typedef NS_OPTIONS(NSUInteger, DZNWebNavigationTools) {
 /**
  Types of supported actions (i.e. Share & Copy link, Add to Reading List, Open in Safari/Chrome/Opera/Dolphin).
  */
-typedef NS_OPTIONS(NSUInteger, DZNsupportedWebActions) {
+typedef NS_OPTIONS(NSInteger, DZNsupportedWebActions) {
     DZNWebActionAll = -1,
     DZNWebActionNone = 0,
     DZNsupportedWebActionshareLink = (1 << 0),

--- a/Source/Classes/DZNWebViewController.m
+++ b/Source/Classes/DZNWebViewController.m
@@ -143,6 +143,7 @@ static char DZNWebViewControllerKVOContext = 0;
 	[super viewDidDisappear:animated];
     
     [self.webView stopLoading];
+    [self clearProgressViewAnimated:animated];
 }
 
 


### PR DESCRIPTION
In some case (for example: a swipe back gesture...),
if the `viewController` call `-viewWillDisappear` before the progress created,
and then, the progressView was created, and loaded to less than 100%,
at last, the `viewController` was disappear by calling `-viewDidDisappear`, the `progressView` will be left in the `navigationBar`.
So, it's necessary to clear `progressView` in `viewDidDisappear`.